### PR TITLE
Remove declaration of direct Wayland support

### DIFF
--- a/org.speed_dreams.SpeedDreams.yaml
+++ b/org.speed_dreams.SpeedDreams.yaml
@@ -5,9 +5,8 @@ sdk: org.freedesktop.Sdk
 command: speed-dreams-2
 
 finish-args:
-  - --socket=wayland
   - --share=ipc
-  - --socket=fallback-x11
+  - --socket=x11
   - --device=all
   - --persist=.speed-dreams-2
   - --socket=pulseaudio


### PR DESCRIPTION
Similar what was experienced in #11, the main game session fails to start on Wayland (main menu works). One workaround is to select `osggraph` as the graphics engine, but I reckon there's a reason the other `ssggraph` is selected as default?

Anyway, to make the game start correctly and with ssggraph out of the box, _direct_ wayland support has to be disabled until the underlying issue w/ `ssggraph` and Wayland is fixed.